### PR TITLE
Apply: fix ambient caps error handling

### DIFF
--- a/capability_linux.go
+++ b/capability_linux.go
@@ -358,11 +358,14 @@ func (c *capsV3) Apply(kind CapType) (err error) {
 			if c.Get(AMBIENT, i) {
 				action = pr_CAP_AMBIENT_RAISE
 			}
-			err := prctl(pr_CAP_AMBIENT, action, uintptr(i), 0, 0)
-			// Ignore EINVAL as not supported on kernels before 4.3
-			if errno, ok := err.(syscall.Errno); ok && errno == syscall.EINVAL {
-				err = nil
-				continue
+			err = prctl(pr_CAP_AMBIENT, action, uintptr(i), 0, 0)
+			if err != nil {
+				// Ignore EINVAL as not supported on kernels before 4.3
+				if errno, ok := err.(syscall.Errno); ok && errno == syscall.EINVAL {
+					err = nil
+					continue
+				}
+				return
 			}
 		}
 	}


### PR DESCRIPTION
Commit e7cb7fa3 added support for ambient capabilities. Unfortunately, the code added to Apply is incorrect because it uses a local variable err which is never used or returned.

Found by a linter:

```
capability_linux.go:480:5: ineffectual assignment to err (ineffassign)
				err = nil
				^
```

Fixes: e7cb7fa3

----

Based on https://github.com/syndtr/gocapability/pull/24