### PR TITLE
Fix linter warnings

### DIFF
--- a/capability_linux.go
+++ b/capability_linux.go
@@ -29,7 +29,7 @@ var (
 
 func init() {
 	var hdr capHeader
-	capget(&hdr, nil)
+	_ = capget(&hdr, nil)
 	capVers = hdr.version
 
 	if initLastCap() == nil {

--- a/capability_linux.go
+++ b/capability_linux.go
@@ -285,15 +285,12 @@ func (c *capsV3) Load() (err error) {
 		return
 	}
 
-	var status_path string
-
-	if c.hdr.pid == 0 {
-		status_path = fmt.Sprintf("/proc/self/status")
-	} else {
-		status_path = fmt.Sprintf("/proc/%d/status", c.hdr.pid)
+	path := "/proc/self/status"
+	if c.hdr.pid != 0 {
+		path = fmt.Sprintf("/proc/%d/status", c.hdr.pid)
 	}
 
-	f, err := os.Open(status_path)
+	f, err := os.Open(path)
 	if err != nil {
 		return
 	}

--- a/enumgen/gen.go
+++ b/enumgen/gen.go
@@ -7,7 +7,6 @@ import (
 	"go/format"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -86,7 +85,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if err := ioutil.WriteFile(genName, src, fi.Mode().Perm()); err != nil {
+	if err := os.WriteFile(genName, src, fi.Mode().Perm()); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
A few very simple linter warning fixes.

----

(Originally opened as https://github.com/syndtr/gocapability/pull/25).