### PR TITLE
Load: don't ignore Sscanf errors

### DIFF
--- a/capability_linux.go
+++ b/capability_linux.go
@@ -304,11 +304,17 @@ func (c *capsV3) Load() (err error) {
 			break
 		}
 		if strings.HasPrefix(line, "CapB") {
-			fmt.Sscanf(line[4:], "nd:  %08x%08x", &c.bounds[1], &c.bounds[0])
+			_, err = fmt.Sscanf(line[4:], "nd:  %08x%08x", &c.bounds[1], &c.bounds[0])
+			if err != nil {
+				break
+			}
 			continue
 		}
 		if strings.HasPrefix(line, "CapA") {
-			fmt.Sscanf(line[4:], "mb:  %08x%08x", &c.ambient[1], &c.ambient[0])
+			_, err = fmt.Sscanf(line[4:], "mb:  %08x%08x", &c.ambient[1], &c.ambient[0])
+			if err != nil {
+				break
+			}
 			continue
 		}
 	}


### PR DESCRIPTION
This fixes errcheck linter warnings:
```
capability_linux.go:311:14: Error return value of `fmt.Sscanf` is not checked (errcheck)
			fmt.Sscanf(line[4:], "nd:  %08x%08x", &c.bounds[1], &c.bounds[0])
			          ^
capability_linux.go:315:14: Error return value of `fmt.Sscanf` is not checked (errcheck)
			fmt.Sscanf(line[4:], "mb:  %08x%08x", &c.ambient[1], &c.ambient[0])
			          ^
```

Once this (and #6) are merged, I can add basic CI.