### PR TITLE
ci: add errorlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,3 +3,4 @@ linters:
     - unconvert
     - unparam
     - gofumpt
+    - errorlint

--- a/capability_linux.go
+++ b/capability_linux.go
@@ -346,7 +346,7 @@ func (c *capsV3) Apply(kind CapType) (err error) {
 				err = prctl(syscall.PR_CAPBSET_DROP, uintptr(i), 0, 0, 0)
 				if err != nil {
 					// Ignore EINVAL since the capability may not be supported in this system.
-					if errno, ok := err.(syscall.Errno); ok && errno == syscall.EINVAL {
+					if err == syscall.EINVAL { //nolint:errorlint // Errors from syscall are bare.
 						err = nil
 						continue
 					}
@@ -372,7 +372,7 @@ func (c *capsV3) Apply(kind CapType) (err error) {
 			err = prctl(pr_CAP_AMBIENT, action, uintptr(i), 0, 0)
 			if err != nil {
 				// Ignore EINVAL as not supported on kernels before 4.3
-				if errno, ok := err.(syscall.Errno); ok && errno == syscall.EINVAL {
+				if err == syscall.EINVAL { //nolint:errorlint // Errors from syscall are bare.
 					err = nil
 					continue
 				}


### PR DESCRIPTION
_This is based on and currently includes #8. Draft until #8 is merged._

With the added linter, it complains like this:
    
> capability_linux.go:349:22: type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors (errorlint)
    
In fact, errors from syscall.Syscall6 used by prctl are bare Errno
values. This means there is no need for a type assertion, so let's
remove it:

```diff
- if errno, ok := err.(syscall.Errno); ok && errno == syscall.EINVAL {
+ if err == syscall.EINVAL {
```    

With that change, we're still getting error from the linter, a bit
different one:
    
> capability_linux.go:349:9: comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error (errorlint)
    
So, we still need to silence it, by adding a nolint annotation.