### PR TITLE
Really fix future kernel compatibility

### DIFF
--- a/capability_linux.go
+++ b/capability_linux.go
@@ -110,11 +110,11 @@ func newPid(pid int) (c Capabilities, retErr error) {
 	case linuxCapVer1, linuxCapVer2:
 		retErr = errors.New("old/unsupported capability version (kernel older than 2.6.26?)")
 	default:
-		// Either linuxCapVer3, or an unknown/future version such as v4.
-		// In the latter case, we fall back to v3 hoping the kernel is
-		// backward-compatible to v3.
+		// Either linuxCapVer3, or an unknown/future version (such as v4).
+		// In the latter case, we fall back to v3 as the latest version known
+		// to this package, as kernel should be backward-compatible to v3.
 		p := new(capsV3)
-		p.hdr.version = ver
+		p.hdr.version = linuxCapVer3
 		p.hdr.pid = int32(pid)
 		c = p
 	}


### PR DESCRIPTION
Earlier commit (see #1) made sure we don't error out if the kernel capability version is unknown; this ensures compatibility with future kernels.

Looking at the code, I realized p.hdr.version should be initialized to linuxCapVer3 in that case, not the version returned by the kernel, otherwise we supply v3 data structure with (say) v4 version set in header.

Practically, this was not a real bug (yet) because v4 is not (yet) available, but if it will ever be introduced later, this fix makes us ready.

Fixes: 558410569e2151 ("Fix future version compatibility")